### PR TITLE
Security fix for GHSA-mrcf-5cch-47mc

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -102,7 +102,7 @@ exports.header = function (uri, method, options) {
         artifacts.hash = Crypto.calculatePayloadHash(options.payload, credentials.algorithm, options.contentType);
     }
 
-    const mac = Crypto.calculateMac('header', credentials, artifacts);
+    const mac = Crypto.generateRequestMac('header', credentials, artifacts);
 
     // Construct header
 
@@ -187,7 +187,7 @@ exports.authenticate = function (res, credentials, artifacts, options) {
     artifacts.ext = serverAuthAttributes.ext;
     artifacts.hash = serverAuthAttributes.hash;
 
-    const mac = Crypto.calculateMac('response', credentials, artifacts);
+    const mac = Crypto.generateRequestMac('response', credentials, artifacts);
     if (mac !== serverAuthAttributes.mac) {
         throw new Boom.Boom('Bad response mac', { decorate: result });
     }
@@ -276,7 +276,7 @@ exports.getBewit = function (uri, options) {
     // Calculate signature
 
     const exp = Math.floor(now / 1000) + options.ttlSec;
-    const mac = Crypto.calculateMac('bewit', credentials, {
+    const mac = Crypto.generateRequestMac('bewit', credentials, {
         ts: exp,
         nonce: '',
         method: 'GET',
@@ -367,11 +367,8 @@ exports.message = function (host, port, message, options) {
         ts: artifacts.ts,
         nonce: artifacts.nonce,
         hash: artifacts.hash,
-        mac: Crypto.calculateMac('message', credentials, artifacts)
+        mac: Crypto.generateRequestMac('message', credentials, artifacts)
     };
 
     return result;
 };
-
-
-

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -19,7 +19,7 @@ exports.headerVersion = '1';                        // Prevent comparison of mac
 exports.algorithms = ['sha1', 'sha256'];
 
 
-// Calculate the request MAC
+// Generates the request MAC
 
 /*
     type: 'header',                                 // 'header', 'bewit', 'response'
@@ -41,13 +41,62 @@ exports.algorithms = ['sha1', 'sha256'];
     }
 */
 
-exports.calculateMac = function (type, credentials, options) {
+exports.generateRequestMac = function (type, credentials, options) {
 
     const normalized = exports.generateNormalizedString(type, options);
 
     const hmac = Crypto.createHmac(credentials.algorithm, credentials.key).update(normalized);
     const digest = hmac.digest('base64');
     return digest;
+};
+
+
+// Calculate the request MAC for verification
+
+/*
+    type: 'header',                                 // 'header', 'bewit', 'response'
+    credentials: {
+        key: 'aoijedoaijsdlaksjdl',
+        algorithm: 'sha256'                         // 'sha1', 'sha256'
+    },
+    options: {
+        method: 'GET',
+        resource: '/resource?a=1&b=2',
+        host: 'example.com',
+        port: 8080,
+        ts: 1357718381034,
+        nonce: 'd3d345f',
+        hash: 'U4MKKSmiVxk37JCCrAVIjV/OhB3y+NdwoCr6RShbVkE=',
+        ext: 'app-specific-data',
+        app: 'hf48hd83qwkj',                        // Application id (Oz)
+        dlg: 'd8djwekds9cj'                         // Delegated by application id (Oz), requires options.app
+    }
+*/
+
+exports.calculateServerMac = function (type, credentials, options, payload, contentType) {
+
+    if (options.hash) {
+        if (!payload) {
+            console.log(`Security Warning: calculateServerMac was called trusting the client payload hash which provides no integrity checking and is insecure`);
+        }
+        else {
+            // never trust client provided hash, always calculate server side
+            options.hash = exports.calculatePayloadHash(payload, credentials.algorithm, contentType);
+        }
+    }
+
+    const normalized = exports.generateNormalizedString(type, options);
+
+    const hmac = Crypto.createHmac(credentials.algorithm, credentials.key).update(normalized);
+    const digest = hmac.digest('base64');
+    return digest;
+};
+
+
+exports.calculateMac = function (type, credentials, options) {
+
+    console.log(`Deprecation Warning: calculateMac() is replaced by either calculateServerMac() or generateRequestMac()`);
+    return exports.generateRequestMac(type, credentials, options);
 };
 
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -153,13 +153,6 @@ exports.authenticate = async function (req, credentialsFunc, options) {
         throw new Boom.Boom('Unknown algorithm', { decorate: result });
     }
 
-    // Calculate MAC
-
-    const mac = Crypto.calculateMac('header', credentials, artifacts);
-    if (!Cryptiles.fixedTimeComparison(mac, attributes.mac)) {
-        throw Object.assign(Utils.unauthorized('Bad mac'), result);
-    }
-
     // Check payload hash
 
     if (options.payload ||
@@ -173,6 +166,13 @@ exports.authenticate = async function (req, credentialsFunc, options) {
         if (!Cryptiles.fixedTimeComparison(hash, attributes.hash)) {
             throw Object.assign(Utils.unauthorized('Bad payload hash'), result);
         }
+    }
+
+    // Calculate MAC
+
+    const mac = Crypto.calculateServerMac('header', credentials, artifacts, options.payload, request.contentType);
+    if (!Cryptiles.fixedTimeComparison(mac, attributes.mac)) {
+        throw Object.assign(Utils.unauthorized('Bad mac'), result);
     }
 
     // Check nonce
@@ -288,7 +288,7 @@ exports.header = function (credentials, artifacts, options) {
         artifacts.hash = Crypto.calculatePayloadHash(options.payload, credentials.algorithm, options.contentType);
     }
 
-    const mac = Crypto.calculateMac('response', credentials, artifacts);
+    const mac = Crypto.calculateServerMac('response', credentials, artifacts, options.payload, options.contentType);
 
     // Construct header
 
@@ -429,7 +429,7 @@ exports.authenticateBewit = async function (req, credentialsFunc, options) {
 
     // Calculate MAC
 
-    const mac = Crypto.calculateMac('bewit', credentials, {
+    const mac = Crypto.generateRequestMac('bewit', credentials, {
         ts: bewit.exp,
         nonce: '',
         method: 'GET',
@@ -508,7 +508,7 @@ exports.authenticateMessage = async function (host, port, message, authorization
 
     // Calculate MAC
 
-    const mac = Crypto.calculateMac('message', credentials, artifacts);
+    const mac = Crypto.generateRequestMac('message', credentials, artifacts);
     if (!Cryptiles.fixedTimeComparison(mac, authorization.mac)) {
         throw Object.assign(Utils.unauthorized('Bad mac'), result);
     }

--- a/test/uri.js
+++ b/test/uri.js
@@ -149,7 +149,7 @@ describe('Uri', () => {
 
         const exp = Math.floor(Hawk.utils.now() / 1000) + 60;
         const ext = 'some-app-data';
-        const mac = Hawk.crypto.calculateMac('bewit', credentials, {
+        const mac = Hawk.crypto.generateRequestMac('bewit', credentials, {
             ts: exp,
             nonce: '',
             method: req.method,
@@ -515,4 +515,3 @@ describe('Uri', () => {
         });
     });
 });
-


### PR DESCRIPTION
Deprecate `calculateMac` replaced by `calculateServerMac` or `generateRequestMac`

Fixes [mozilla/hawk#284](https://github.com/mozilla/hawk/issues/284)